### PR TITLE
fix document name rendering

### DIFF
--- a/src/app/general/[chatId]/_components/ChatHeader.tsx
+++ b/src/app/general/[chatId]/_components/ChatHeader.tsx
@@ -33,7 +33,7 @@ export function ChatHeader() {
         setSelectedChat(undefined);
       }
     })();
-  }, [pathname]);
+  }, [pathname , selectedChat]);
 
   const handleKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (!title.length) return;


### PR DESCRIPTION
Resolved: When user chats with the bot and then upload the document. The document name is showing in the the badge of attach knowledge