### PR TITLE
invalidating cache when deleting the messages

### DIFF
--- a/src/app/_components/ChatMessages.tsx
+++ b/src/app/_components/ChatMessages.tsx
@@ -10,7 +10,7 @@ import {
   Message,
 } from "@/app/_lib/db";
 import { askRS_sendMessage as apiSendMessage } from "@/dal/message";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { store } from "@/app/_utils/store";
 
@@ -35,6 +35,7 @@ export function ChatMessages() {
   const [messages, setMessages] = useState<AskRSMessage[]>([]);
   const { set, useSnapshot } = store;
   const { clearChat } = useSnapshot();
+  const queryClient = useQueryClient();
 
   const { mutateAsync: sendMessageMutation, isPending } = useMutation({
     mutationFn: apiSendMessage,
@@ -58,6 +59,7 @@ export function ChatMessages() {
       return await getAllMessages_aRS();
     },
     enabled: !!uId,
+    staleTime: 0
   });
 
   useEffect(() => {
@@ -71,6 +73,7 @@ export function ChatMessages() {
       setMessages([]);
       set("clearChat", false);
     }
+    queryClient.invalidateQueries({ queryKey: ['messages', 'askRS'] });
   }, [clearChat]);
 
   useEffect(() => {


### PR DESCRIPTION
## PR Title: Invalidating cache when deleting the messages

### Description
When deleting messages on ask ripeseed page, cache is now invalidated so when the user comes back on the screen they don't see older messages.

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change
- [ ] Documentation update
- [ ] 
### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
