### PR TITLE
Fixed alignement and selection of text in buttons

### DIFF
--- a/src/app/ask-anything/[chatId]/_components/WelcomeCards.tsx
+++ b/src/app/ask-anything/[chatId]/_components/WelcomeCards.tsx
@@ -57,7 +57,7 @@ export const WelcomeCards = ({
             className="flex h-24 w-full cursor-pointer items-center justify-center border border-[#CECECE] bg-[#EFEFEF] p-2 text-lightText shadow-sm dark:border-[#3C3C3F] dark:bg-[#404043] dark:text-darkText"
             onClick={() => messageHandler(cards.top)}
           >
-            <div>
+            <div className="text-center">
               <Image
                 src={clock}
                 alt="clock"
@@ -74,7 +74,7 @@ export const WelcomeCards = ({
               className="flex h-24 w-full cursor-pointer items-center justify-center border border-[#CECECE] bg-[#EFEFEF] p-2 text-lightText shadow-sm dark:border-[#3C3C3F] dark:bg-[#404043] dark:text-darkText"
               onClick={() => messageHandler(cards.bottomLeft)}
             >
-              <div>
+              <div className="text-center">
                 <Image
                   src={clock}
                   alt="clock"
@@ -90,7 +90,7 @@ export const WelcomeCards = ({
               className="flex h-24 w-full cursor-pointer items-center justify-center border border-[#CECECE] bg-[#EFEFEF] p-2 text-lightText shadow-sm dark:border-[#3C3C3F] dark:bg-[#404043] dark:text-darkText"
               onClick={() => messageHandler(cards.bottomRight)}
             >
-              <div>
+              <div className="text-center">
                 <Image
                   src={clock}
                   alt="clock"

--- a/src/components/common/_components/ChatButtonsHeader.tsx
+++ b/src/components/common/_components/ChatButtonsHeader.tsx
@@ -37,13 +37,13 @@ export default function ChatHeader() {
       <div className="flex gap-1 rounded-full bg-[#E0E0E0] text-[#575757] dark:bg-[#5E5E61] dark:text-white">
         <li
           onClick={() => router.push("/")}
-          className={`cursor-pointer list-none px-2 py-1 font-medium transition-all duration-300 ease-linear xs:px-6 md:py-2 md:text-lg ${isPath(askRSPaths, pathname) ? "rounded-full bg-crayola text-white drop-shadow-lg" : "rounded-full hover:bg-accent"} `}
+          className={`select-none cursor-pointer list-none px-2 py-1 font-medium transition-all duration-300 ease-linear xs:px-6 md:py-2 md:text-lg ${isPath(askRSPaths, pathname) ? "rounded-full bg-crayola text-white drop-shadow-lg" : "rounded-full hover:bg-accent"} `}
         >
           Ask RipeSeed
         </li>
         <li
           onClick={() => router.push("/ask-anything")}
-          className={`cursor-pointer list-none px-2 py-1 font-medium transition-all duration-300 ease-linear xs:px-6 md:py-2 md:text-lg ${isPath(generalPaths, pathname) ? "rounded-full bg-crayola text-white drop-shadow-lg" : "rounded-full hover:bg-accent"}`}
+          className={`select-none cursor-pointer list-none px-2 py-1 font-medium transition-all duration-300 ease-linear xs:px-6 md:py-2 md:text-lg ${isPath(generalPaths, pathname) ? "rounded-full bg-crayola text-white drop-shadow-lg" : "rounded-full hover:bg-accent"}`}
         >
           Ask Anything
         </li>


### PR DESCRIPTION
## Fixed alignement and selection of text in buttons

### Description
When user was clicking on the buttons of "Ask RipeSeed" or "Ask Anything" on mobile, it was selecting the text before navigating to the requested page.
Moreover, the text in the cards was left aligned so centred that as well.

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change
- [ ] Documentation update

### How Has This Been Tested?
Opened mobile view on the web (inspection tool) and tried selecting the text which didn't happen anymore.

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### Before and After images for reference
<img width="396" alt="image" src="https://github.com/user-attachments/assets/024df50e-a72b-4100-b401-ff482e6318ba">
<img width="396" alt="image" src="https://github.com/user-attachments/assets/0938b9ca-57aa-49ba-ba7e-41ae85e267a3">

