### PR TITLE
Removed unnecessary sorting after chat rename

### DIFF
--- a/src/app/ask-anything/[chatId]/_components/ChatHeader.tsx
+++ b/src/app/ask-anything/[chatId]/_components/ChatHeader.tsx
@@ -76,10 +76,7 @@ export function ChatHeader() {
     });
 
     const updated = await getAllChats();
-    const sorted = updated.sort((a, b) => {
-      return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-    });
-    set("chats", sorted);
+    set("chats", updated);
 
     const updatedChat = await getChat({ id });
 


### PR DESCRIPTION
## Removed unnecessary sorting after chat rename

### Description
After the chat is renames, we don't have to rearrange and bring the updated chat on top because they are being sorted on basis of creation date.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change
- [ ] Documentation update

### How Has This Been Tested?
[Describe the steps you perform to verify your changes. Provide instructions so we can reproduce. Preferablly a LOOM would be helpful]

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings