### PR TITLE
Removed unnecessary sorting after delete

### DIFF
--- a/src/app/@sidebar/_components/GeneralSidebar.tsx
+++ b/src/app/@sidebar/_components/GeneralSidebar.tsx
@@ -76,14 +76,7 @@ export default function GeneralSideBar() {
       set("selectedChat", allChats[len - 1]);
       router.push(`/ask-anything/${allChats[len - 1].id}`);
     }
-    set(
-      "chats",
-      allChats.sort((a, b) => {
-        return (
-          new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
-        );
-      }),
-    );
+    set("chats", allChats);
 
     closeRef.current?.click();
   };


### PR DESCRIPTION
## Removed unnecessary sorting after delete

### Description
When a chat is deleted from the sidebar, the sidebar chats shouldn't be sorted on updatedAt() because they are being sorted as we want them, from the backend.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change
- [ ] Documentation update

### How Has This Been Tested?
- Create new chat, delete the chat
- Delete first and last chats

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
