### PR TITLE
Replaced useEffect containing API call with useQuery

### DIFF
--- a/src/app/ask-anything/[chatId]/_components/ChatHeader.tsx
+++ b/src/app/ask-anything/[chatId]/_components/ChatHeader.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Chat, getAllChats, getChat, updateChat } from "@/app/_lib/db";
+import { getAllChats, getChat, updateChat } from "@/app/_lib/db";
 import { truncateString } from "@/app/_utils";
 import { store } from "@/app/_utils/store";
 import { PencilLine } from "lucide-react";
@@ -21,36 +21,28 @@ export function ChatHeader() {
     }
   };
 
-
   const pathname = usePathname();
 
-  useEffect(()=>{
-    const getChatId = async() => {
+  useEffect(() => {
+    const getChatId = async () => {
       const id = Number(pathname.split("/")[2]);
-      
       const chatId = isNaN(id) ? null : id;
-    
-    if(chatId){
-      const updatedChat = await getChat({ id });
-    
+      if (chatId) {
+        const updatedChat = await getChat({ id });
         set("selectedChat", updatedChat);
-    }
-    }
-  
-    getChatId()
-  },[pathname])
+      }
+    };
+    getChatId();
+  }, [pathname]);
 
   useEffect(() => {
     const checkScreenSize = () => {
       setIsSmScreen(window.innerWidth < 768);
     };
-
     // Set initial value
     checkScreenSize();
-
     // Add event listener
     window.addEventListener('resize', checkScreenSize);
-
     // Clean up the event listener on component unmount
     return () => window.removeEventListener('resize', checkScreenSize);
   }, []);


### PR DESCRIPTION
## Replaced useEffect containing API call with useQuery

### Description
To get all chats after a chat is deleted, an API was being called in useEffect while everywhere else in the application, useQuery was used. To maintain consistency across components, the useEffects is replaced by the useQuery call.

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change
- [ ] Documentation update

### How Has This Been Tested?
Added a lot of chats and tried deleting first, last and mid chats to see if it's not breaking anything.

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
