### PR TITLE
fix: moved from valtio to zustand

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "sonner": "^1.4.41",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
-    "valtio": "^1.13.2"
+    "zustand": "^5.0.1"
   },
   "devDependencies": {
     "@cloudflare/next-on-pages": "^1.11.3",

--- a/src/app/_utils/store/index.ts
+++ b/src/app/_utils/store/index.ts
@@ -1,5 +1,5 @@
 import { Chat } from '@/app/_lib/db'
-import { ValtioWrapper } from './classes'
+import { ZustandWrapper } from './classes'
 
 export const initialState: {
   chats: Chat[]
@@ -31,4 +31,4 @@ export const initialState: {
   },
 }
 
-export const store = new ValtioWrapper(initialState)
+export const store = new ZustandWrapper(initialState)


### PR DESCRIPTION
## PR Title: Refactor Store Management to Integrate Zustand, Mimicking Valtio's API

### Description
This pull request refactors the state management in the project to use Zustand instead of Valtio, while maintaining the same function names and usage patterns.

### Related Issue
N/A

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change
- [ ] Documentation update

### How Has This Been Tested?
- Replaced the Valtio store with the Zustand wrapper in the project.
- Verified that the state is updated correctly using the `set` method.
- Ensured the `useSnapshot` hook works as expected to read state values.
- Tested resetting the state using the `clear` method.
- Checked that complex nested state updates (like updating `stateMetadata`) work without issues.
- Ran through typical state manipulation scenarios in the project to ensure the change didn’t break any functionality.

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
