### PR TITLE
fix: initial feedback | Drop down and Button gap | Toggle hidden on other pages

### DIFF
--- a/src/components/common/_components/ChatButtonsHeader.tsx
+++ b/src/components/common/_components/ChatButtonsHeader.tsx
@@ -46,15 +46,17 @@ export default function ChatHeader() {
           Ask Anything
         </li>
       </div>
-      <div className='flex items-center absolute right-0 mr-[14px]'>
-        <div className="flex items-center justify-center">
-          <ModelSelect />
-        </div>
+      <div className='flex items-center absolute right-0 mr-[14px] gap-1'>
         {isPath(askRSPaths, pathname) ? (
-          askRSmsg ? (
-            <DeleteConfirmationDialog />
-          ) : null
-        ) : (
+            <>
+              <div className="flex items-center justify-center">
+                <ModelSelect />
+              </div>
+              {askRSmsg ? (
+                <DeleteConfirmationDialog />
+              ) : null}
+            </>
+          ) : (
           <ConfigDialogue />
         )}
       </div>


### PR DESCRIPTION
fix: initial feedback | Drop down and Button gap | Toggle hidden on other pages

### Description
- Drop down and Button gap
- Toggle hidden on other pages.

### Related Issue
[Link to the related issue or ticket, if applicable]

### Type of Change
- [x] Enhancement
