### PR TITLE
Add assistant message action buttons (Copy, Thumbs Up/Down)

### DIFF
--- a/src/app/_components/MessageList.tsx
+++ b/src/app/_components/MessageList.tsx
@@ -67,6 +67,11 @@ export function MessageList({ messages, status, cards }: MessageListProps) {
                   createdAt: new Date().toString(),
                   updatedAt: new Date().toString(),
                 }}
+                hideActions={
+                  message.role === 'assistant' &&
+                  i === messages.length - 1 &&
+                  (status === 'streaming' || status === 'submitted')
+                }
               />
             )}
             {bookMeetingTool && bookMeetingTool.type === 'tool-bookMeeting' && (

--- a/src/app/ask-anything/[chatId]/_components/ChatMessages.tsx
+++ b/src/app/ask-anything/[chatId]/_components/ChatMessages.tsx
@@ -338,7 +338,15 @@ export function ChatMessages() {
               {messages.map(
                 (message, i) =>
                   message.content && (
-                    <MessageContainer message={message} key={i} />
+                    <MessageContainer
+                      message={message}
+                      key={i}
+                      hideActions={
+                        message.role === 'assistant' &&
+                        waitingForStream &&
+                        i === messages.length - 1
+                      }
+                    />
                   ),
               )}
               {waitingForStream && (

--- a/src/app/ask-anything/[chatId]/_components/MessageActions.tsx
+++ b/src/app/ask-anything/[chatId]/_components/MessageActions.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { useState } from 'react'
+import { Copy, CopyCheck, ThumbsDown, ThumbsUp } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { Button } from '@/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+type Feedback = 'up' | 'down' | null
+
+interface MessageActionsProps {
+  content: string
+  className?: string
+}
+
+export function MessageActions({ content, className }: MessageActionsProps) {
+  const [copied, setCopied] = useState(false)
+  const [feedback, setFeedback] = useState<Feedback>(null)
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(content)
+      setCopied(true)
+      toast.success('Copied to clipboard')
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      toast.error('Failed to copy')
+    }
+  }
+
+  const handleFeedback = (value: 'up' | 'down') => {
+    setFeedback((prev) => (prev === value ? null : value))
+  }
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <div className={cn('flex items-center gap-1', className)}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type='button'
+              variant='ghost'
+              size='icon'
+              className='h-8 w-8 text-muted-foreground hover:text-foreground'
+              aria-label='Copy'
+              onClick={handleCopy}
+            >
+              {copied ? (
+                <CopyCheck className='h-4 w-4' />
+              ) : (
+                <Copy className='h-4 w-4' />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Copy</TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type='button'
+              variant='ghost'
+              size='icon'
+              className={cn(
+                'h-8 w-8 text-muted-foreground hover:text-foreground',
+                feedback === 'up' && 'text-green-600 hover:text-green-600',
+              )}
+              aria-label='Thumbs up'
+              aria-pressed={feedback === 'up'}
+              onClick={() => handleFeedback('up')}
+            >
+              <ThumbsUp
+                className={cn('h-4 w-4', feedback === 'up' && 'fill-current')}
+              />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Thumbs up</TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type='button'
+              variant='ghost'
+              size='icon'
+              className={cn(
+                'h-8 w-8 text-muted-foreground hover:text-foreground',
+                feedback === 'down' && 'text-red-600 hover:text-red-600',
+              )}
+              aria-label='Thumbs down'
+              aria-pressed={feedback === 'down'}
+              onClick={() => handleFeedback('down')}
+            >
+              <ThumbsDown
+                className={cn('h-4 w-4', feedback === 'down' && 'fill-current')}
+              />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Thumbs down</TooltipContent>
+        </Tooltip>
+      </div>
+    </TooltipProvider>
+  )
+}

--- a/src/app/ask-anything/[chatId]/_components/MessageContainer.tsx
+++ b/src/app/ask-anything/[chatId]/_components/MessageContainer.tsx
@@ -1,8 +1,8 @@
-import { motion } from 'framer-motion'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
 
 import { Message } from '@/app/_lib/db'
+import { MessageActions } from '@/app/ask-anything/[chatId]/_components/MessageActions'
 import ShowMessage from '@/app/ask-anything/[chatId]/_components/ShowMessage'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { cn } from '@/lib/utils'
@@ -12,6 +12,7 @@ import 'katex/dist/katex.min.css'
 interface MessageContainerProps {
   message: Message
   isPending?: boolean
+  hideActions?: boolean
 }
 
 const components = {
@@ -49,7 +50,11 @@ const components = {
 export const MessageContainer = ({
   message,
   isPending,
+  hideActions = false,
 }: MessageContainerProps) => {
+  const showActions =
+    message.role === 'assistant' && !isPending && !hideActions
+
   return (
     <div
       className={cn(
@@ -59,34 +64,28 @@ export const MessageContainer = ({
           : 'items-start',
       )}
     >
-      <div className='flex items-center'>
-        {message.role === 'assistant' && (
-          <div className='flex h-full flex-col'>
-            <div className='flex-grow'></div>
-            <Avatar className='mb-3 flex items-center justify-center border border-[#DBDBDB] p-0.5 dark:border-[#D1D1D1]'>
-              <AvatarImage
-                src={`/logo/logo.svg`}
-                alt={message.role}
-                width={100}
-                height={100}
-              />
-            </Avatar>
-          </div>
-        )}
-        <span className='max-w-[90%] overflow-x-auto rounded-md p-3 text-white sm:max-w-sm md:max-w-md'>
-          {isPending ? (
-            <div className='flex items-center justify-center gap-2'>
-              <span className='sr-only'>Thinking ...</span>
-              <div className='h-1 w-1 animate-bounce rounded-full bg-red-200 [animation-delay:-0.4s]'></div>
-              <div className='h-1 w-1 animate-bounce rounded-full bg-gray-500 [animation-delay:-0.2s]'></div>
-              <div className='h-1 w-1 animate-bounce rounded-full bg-gray-500 [animation-delay:-0.2s]'></div>
-              <div className='h-1 w-1 animate-bounce rounded-full bg-gray-500 [animation-delay:-0.2s]'></div>
+      {message.role === 'assistant' ? (
+        <div className='flex w-full flex-col items-start gap-1'>
+          <div className='flex items-center'>
+            <div className='flex h-full flex-col'>
+              <div className='flex-grow'></div>
+              <Avatar className='mb-3 flex items-center justify-center border border-[#DBDBDB] p-0.5 dark:border-[#D1D1D1]'>
+                <AvatarImage
+                  src={`/logo/logo.svg`}
+                  alt={message.role}
+                  width={100}
+                  height={100}
+                />
+              </Avatar>
             </div>
-          ) : (
-            <>
-              {message.role === 'user' ? (
-                <div className='prose rounded-xl bg-[#EBEBEB] p-3 text-black dark:bg-[#404043] dark:text-white'>
-                  {message.content}
+            <span className='max-w-[90%] overflow-x-auto rounded-md p-3 text-white sm:max-w-sm md:max-w-md'>
+              {isPending ? (
+                <div className='flex items-center justify-center gap-2'>
+                  <span className='sr-only'>Thinking ...</span>
+                  <div className='h-1 w-1 animate-bounce rounded-full bg-red-200 [animation-delay:-0.4s]'></div>
+                  <div className='h-1 w-1 animate-bounce rounded-full bg-gray-500 [animation-delay:-0.2s]'></div>
+                  <div className='h-1 w-1 animate-bounce rounded-full bg-gray-500 [animation-delay:-0.2s]'></div>
+                  <div className='h-1 w-1 animate-bounce rounded-full bg-gray-500 [animation-delay:-0.2s]'></div>
                 </div>
               ) : (
                 <ShowMessage
@@ -94,10 +93,22 @@ export const MessageContainer = ({
                   components={components}
                 />
               )}
-            </>
+            </span>
+          </div>
+          {showActions && (
+            <MessageActions
+              content={String(message.content)}
+              className='pl-10 md:pl-12'
+            />
           )}
-        </span>
-        {message.role === 'user' && (
+        </div>
+      ) : (
+        <div className='flex items-center'>
+          <span className='max-w-[90%] overflow-x-auto rounded-md p-3 text-white sm:max-w-sm md:max-w-md'>
+            <div className='prose rounded-xl bg-[#EBEBEB] p-3 text-black dark:bg-[#404043] dark:text-white'>
+              {message.content}
+            </div>
+          </span>
           <div className='relative flex h-full flex-col'>
             <Avatar className='mt-[12px] flex items-center justify-center border'>
               <AvatarImage
@@ -110,8 +121,8 @@ export const MessageContainer = ({
               <AvatarFallback>{'User'}</AvatarFallback>
             </Avatar>
           </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Adds a **Copy**, **Thumbs Up**, and **Thumbs Down** action row below every completed AI assistant message in both Ask RipeSeed and Ask Anything chat flows.
- Feedback is **client-only** (toggle state in the UI; no API or database changes).
- Actions are **hidden** on the last assistant message while a response is still streaming.

## Changes

- New `MessageActions` component with clipboard copy (toast confirmation) and thumb toggles
- `MessageContainer` renders actions below assistant bubbles, aligned with existing content offset
- `MessageList` and `ChatMessages` pass `hideActions` during active streaming

## Test plan

- [ ] Ask RipeSeed (`/`): actions appear after response completes, not during "Thinking..." or mid-stream
- [ ] Ask Anything: same behavior in a local chat
- [ ] Copy copies message markdown source and shows toast
- [ ] Thumbs up/down toggle; clicking active thumb deselects
- [ ] No action row on user messages
- [ ] Buttons usable in dark mode


Made with [Cursor](https://cursor.com)