### PR TITLE
Add Ask Anything conversation export as markdown

### DIFF
--- a/src/app/_utils/exportConversation.ts
+++ b/src/app/_utils/exportConversation.ts
@@ -1,0 +1,63 @@
+import { Message } from '@/app/_lib/db/types'
+
+const BOOK_MEETING_PLACEHOLDER = '_[Meeting booking widget]_'
+
+function formatMessageContent(content: string): string {
+  if (content.trim() === 'BOOK_MEETING') {
+    return BOOK_MEETING_PLACEHOLDER
+  }
+  return content
+}
+
+function formatTimestamp(isoString: string): string {
+  return new Date(isoString).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })
+}
+
+function formatRole(role: Message['role']): string {
+  return role === 'user' ? 'User' : 'Assistant'
+}
+
+export function formatConversationMarkdown(
+  title: string,
+  messages: Message[],
+): string {
+  const sorted = [...messages].sort(
+    (a, b) =>
+      new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+  )
+
+  const sections = sorted.map((message) => {
+    const heading = `## ${formatRole(message.role)} · ${formatTimestamp(message.createdAt)}`
+    const body = formatMessageContent(message.content)
+    return `${heading}\n\n${body}`
+  })
+
+  return [`# ${title}`, '', '---', '', ...sections].join('\n')
+}
+
+export function sanitizeFilename(name: string, fallbackId?: number): string {
+  const sanitized = name
+    .trim()
+    .replace(/[/\\?%*:|"<>]/g, '')
+    .replace(/\s+/g, '-')
+    .slice(0, 100)
+
+  if (sanitized.length > 0) {
+    return sanitized
+  }
+
+  return fallbackId != null ? `chat-${fallbackId}` : 'chat'
+}
+
+export function downloadMarkdownFile(filename: string, content: string): void {
+  const blob = new Blob([content], { type: 'text/markdown;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = filename.endsWith('.md') ? filename : `${filename}.md`
+  anchor.click()
+  URL.revokeObjectURL(url)
+}

--- a/src/app/ask-anything/[chatId]/_components/ChatHeader.tsx
+++ b/src/app/ask-anything/[chatId]/_components/ChatHeader.tsx
@@ -8,6 +8,7 @@ import { getAllChats, getChat, updateChat } from '@/app/_lib/db'
 import { truncateString } from '@/app/_utils'
 import useStore from '@/app/_utils/store/store'
 import { Input } from '@/components/ui/input'
+import { DownloadConversationButton } from './DownloadConversationButton'
 import { UploadDocumentWrapper } from './UploadDocumentWrapper'
 
 export function ChatHeader() {
@@ -116,7 +117,13 @@ export function ChatHeader() {
       </div>
       <div className='col-start-3 col-end-4 row-start-1 row-end-2 flex items-center justify-end px-3 md:px-10'>
         {(!isSmScreen || !isEditing) && (
-          <UploadDocumentWrapper selectedChat={selectedChat} />
+          <div className='flex items-center gap-2'>
+            <DownloadConversationButton
+              chatId={selectedChat?.id}
+              chatName={selectedChat?.name}
+            />
+            <UploadDocumentWrapper selectedChat={selectedChat} />
+          </div>
         )}
       </div>
     </div>

--- a/src/app/ask-anything/[chatId]/_components/DownloadConversationButton.tsx
+++ b/src/app/ask-anything/[chatId]/_components/DownloadConversationButton.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useState } from 'react'
+import { Tooltip } from '@nextui-org/tooltip'
+import { Download } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { getAllMessagesByChat } from '@/app/_lib/db'
+import {
+  downloadMarkdownFile,
+  formatConversationMarkdown,
+  sanitizeFilename,
+} from '@/app/_utils/exportConversation'
+import { Button } from '@/components/ui/button'
+
+export function DownloadConversationButton({
+  chatId,
+  chatName,
+}: {
+  chatId: number | undefined
+  chatName: string | undefined
+}) {
+  const [isExporting, setIsExporting] = useState(false)
+
+  const handleDownload = async () => {
+    if (!chatId || isExporting) return
+
+    setIsExporting(true)
+    try {
+      const messages = await getAllMessagesByChat({ chatId })
+
+      if (messages.length === 0) {
+        toast.info('No messages to export')
+        return
+      }
+
+      const title = chatName?.trim() || `Chat ${chatId}`
+      const markdown = formatConversationMarkdown(title, messages)
+      const filename = sanitizeFilename(title, chatId)
+
+      downloadMarkdownFile(filename, markdown)
+      toast.success('Conversation downloaded')
+    } catch {
+      toast.error('Failed to export conversation')
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
+  return (
+    <Tooltip
+      content='Download conversation as Markdown'
+      placement='bottom'
+      classNames={{
+        content: [
+          'text-white mx-auto w-max max-w-xs rounded-md bg-gray-800 p-1 text-xs text-white shadow-lg',
+        ],
+      }}
+    >
+      <Button
+        variant='outline'
+        disabled={!chatId || isExporting}
+        onClick={handleDownload}
+        className='group max-w-48 cursor-pointer rounded-3xl border border-[#575757] bg-transparent px-3 text-xs text-[#575757] transition duration-300 hover:border-crayola hover:bg-transparent dark:border-white dark:text-white dark:hover:border-crayola md:px-5'
+      >
+        <div className='flex items-center gap-2'>
+          <Download className='h-4 w-4 transition duration-300 group-hover:text-crayola dark:text-[#EBEBEB]' />
+          <span className='hidden font-semibold transition duration-300 group-hover:text-crayola md:inline'>
+            Download
+          </span>
+        </div>
+      </Button>
+    </Tooltip>
+  )
+}


### PR DESCRIPTION
## Summary

- Add a **Download** button to the Ask Anything per-chat header that exports the current conversation as a `.md` file
- Export reads messages from IndexedDB client-side (no new API route)
- Markdown includes chat title, role/timestamp headings, and message content; `BOOK_MEETING` is replaced with a placeholder

## Test plan

- [ ] Open an Ask Anything chat with messages and click **Download** — verify `.md` file downloads with correct title, roles, and content
- [ ] Open a chat with no messages — verify info toast, no file download
- [ ] Chat with `BOOK_MEETING` response — verify placeholder in export
- [ ] Mobile viewport while editing title — download button hidden alongside Attach Knowledge


Made with [Cursor](https://cursor.com)